### PR TITLE
Add legal policy pages and footer links

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -5,6 +5,9 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { BrowserRouter, Routes, Route } from "react-router-dom";
 import Index from "./pages/Index";
 import NotFound from "./pages/NotFound";
+import TermsOfUse from "./pages/TermsOfUse";
+import PrivacyPolicy from "./pages/PrivacyPolicy";
+import RefundPolicy from "./pages/RefundPolicy";
 
 const queryClient = new QueryClient();
 
@@ -16,6 +19,9 @@ const App = () => (
       <BrowserRouter>
         <Routes>
           <Route path="/" element={<Index />} />
+          <Route path="/terminos" element={<TermsOfUse />} />
+          <Route path="/privacidad" element={<PrivacyPolicy />} />
+          <Route path="/reembolsos" element={<RefundPolicy />} />
           {/* ADD ALL CUSTOM ROUTES ABOVE THE CATCH-ALL "*" ROUTE */}
           <Route path="*" element={<NotFound />} />
         </Routes>

--- a/src/components/landing/footer.tsx
+++ b/src/components/landing/footer.tsx
@@ -116,6 +116,19 @@ export function Footer() {
             <p className="text-gray-400 text-sm order-2 md:order-1 text-center md:text-left">
               © {new Date().getFullYear()} COINNECTA. Todos los derechos reservados.
             </p>
+            <div className="flex space-x-4 text-gray-400 text-sm order-1 md:order-2">
+              <a href="/terminos" className="hover:text-golden transition-colors">
+                Términos de Uso
+              </a>
+              <span className="hidden md:block">|</span>
+              <a href="/privacidad" className="hover:text-golden transition-colors">
+                Política de Privacidad
+              </a>
+              <span className="hidden md:block">|</span>
+              <a href="/reembolsos" className="hover:text-golden transition-colors">
+                Política de Reembolsos
+              </a>
+            </div>
           </div>
           
           <p className="text-xs text-gray-500 mt-6 text-center md:text-left">

--- a/src/pages/PrivacyPolicy.tsx
+++ b/src/pages/PrivacyPolicy.tsx
@@ -1,0 +1,27 @@
+const PrivacyPolicy = () => (
+  <div className="min-h-screen bg-gradient-to-b from-gray-900 to-gray-950 text-gray-100 py-20 px-4">
+    <div className="container mx-auto max-w-3xl space-y-6">
+      <h1 className="text-4xl font-bold mb-10 text-center">Política de Privacidad</h1>
+      <p>
+        En COINNECTA valoramos tu privacidad. Esta política explica cómo recopilamos,
+        utilizamos y protegemos tu información personal cuando usas nuestro sitio web
+        y servicios.
+      </p>
+      <p>
+        Solo recopilamos los datos necesarios para brindarte una experiencia segura
+        y personalizada. Nunca compartiremos tu información con terceros sin tu
+        consentimiento, salvo cuando lo exija la ley.
+      </p>
+      <p>
+        Puedes ejercer tus derechos de acceso, rectificación o eliminación de tus
+        datos personales escribiéndonos a
+        <a href="mailto:hola@coinnecta.com" className="text-golden underline ml-1">
+          hola@coinnecta.com
+        </a>
+        .
+      </p>
+    </div>
+  </div>
+);
+
+export default PrivacyPolicy;

--- a/src/pages/RefundPolicy.tsx
+++ b/src/pages/RefundPolicy.tsx
@@ -1,0 +1,25 @@
+const RefundPolicy = () => (
+  <div className="min-h-screen bg-gradient-to-b from-gray-900 to-gray-950 text-gray-100 py-20 px-4">
+    <div className="container mx-auto max-w-3xl space-y-6">
+      <h1 className="text-4xl font-bold mb-10 text-center">Política de Reembolsos</h1>
+      <p>
+        Queremos que estés satisfecho con tu compra en COINNECTA. Si el contenido no
+        cumple con tus expectativas, puedes solicitar un reembolso dentro de los 7
+        días posteriores a la compra.
+      </p>
+      <p>
+        Para iniciar el proceso, contáctanos a través de
+        <a href="mailto:hola@coinnecta.com" className="text-golden underline ml-1">
+          hola@coinnecta.com
+        </a>
+        indicando el motivo de tu solicitud y los detalles de tu compra.
+      </p>
+      <p>
+        Las solicitudes recibidas después de este período no serán elegibles para
+        reembolso.
+      </p>
+    </div>
+  </div>
+);
+
+export default RefundPolicy;

--- a/src/pages/TermsOfUse.tsx
+++ b/src/pages/TermsOfUse.tsx
@@ -1,0 +1,31 @@
+const TermsOfUse = () => (
+  <div className="min-h-screen bg-gradient-to-b from-gray-900 to-gray-950 text-gray-100 py-20 px-4">
+    <div className="container mx-auto max-w-3xl space-y-6">
+      <h1 className="text-4xl font-bold mb-10 text-center">Términos de Uso</h1>
+      <p>
+        Bienvenido a COINNECTA. Al acceder y utilizar nuestro sitio web y servicios,
+        aceptas cumplir con los siguientes términos y condiciones. Si no estás de
+        acuerdo con alguna parte de estos términos, te recomendamos no utilizar
+        nuestra plataforma.
+      </p>
+      <p>
+        Todo el contenido disponible en este sitio es propiedad de COINNECTA y está
+        protegido por las leyes de derechos de autor. No se permite su reproducción
+        total o parcial sin autorización expresa.
+      </p>
+      <p>
+        Nos reservamos el derecho de modificar estos términos en cualquier momento.
+        Las modificaciones entrarán en vigor una vez publicadas en este sitio.
+      </p>
+      <p>
+        Si tienes alguna pregunta, puedes contactarnos en
+        <a href="mailto:hola@coinnecta.com" className="text-golden underline ml-1">
+          hola@coinnecta.com
+        </a>
+        .
+      </p>
+    </div>
+  </div>
+);
+
+export default TermsOfUse;


### PR DESCRIPTION
## Summary
- create Terms of Use, Privacy Policy and Refund Policy pages styled with site design
- link new legal pages from footer and routing

## Testing
- `npm run lint` *(fails: @typescript-eslint/no-empty-object-type and @typescript-eslint/no-require-imports)*

------
https://chatgpt.com/codex/tasks/task_e_68a607fe5ea4832a8905f7747c6af5e5