### PR TITLE
Update pricing to 20 USD and use new checkout link

### DIFF
--- a/src/components/landing/content-section.tsx
+++ b/src/components/landing/content-section.tsx
@@ -182,8 +182,8 @@ export function ContentSection() {
             <div className="sm:hidden mb-4">
               <p className="text-white/80 text-sm">Valor total:</p>
               <p className="text-2xl font-black text-white">
-                <span className="line-through text-white/50">€3,000</span>{" "}
-                <span className="text-golden">€9.99</span>
+                <span className="line-through text-white/50">$3,000</span>{" "}
+                <span className="text-golden">20 USD</span>
               </p>
               <p className="text-white/80 text-sm mt-2">
                 Oferta termina en: <span className="text-golden">{timeLeft.days}d {timeLeft.hours}h {timeLeft.minutes}m</span>
@@ -195,8 +195,8 @@ export function ContentSection() {
               <div className="text-left">
                 <p className="text-white/80 text-sm">Valor total:</p>
                 <p className="text-2xl font-black text-white">
-                  <span className="line-through text-white/50">€3,000</span>{" "}
-                  <span className="text-golden">€9.99</span>
+                  <span className="line-through text-white/50">$3,000</span>{" "}
+                  <span className="text-golden">20 USD</span>
                 </p>
               </div>
               
@@ -213,7 +213,7 @@ export function ContentSection() {
             <CTAButton 
               size="xl" 
               className="w-full sm:w-auto hover:scale-105 transition-transform duration-300 shadow-lg shadow-golden/30 relative overflow-hidden"
-              onClick={() => window.open('https://academia.coinnecta.es/producto/suscripcion-mensual-academia/', '_blank')}
+              onClick={() => window.open('https://www.skool.com/coinnecta-8616', '_blank')}
             >
               <span className="relative z-10">🚀 Quiero Comenzar Ahora</span>
               <span className="absolute inset-0 bg-gradient-to-r from-transparent via-white/30 to-transparent opacity-0 hover:opacity-100 transition-opacity duration-500 -rotate-45 scale-150"></span>

--- a/src/components/landing/creator-section.tsx
+++ b/src/components/landing/creator-section.tsx
@@ -97,7 +97,7 @@ export function CreatorSection() {
               <CTAButton 
                 size="xl" 
                 className="bg-gradient-to-r from-golden to-amber-500 hover:from-amber-500 hover:to-golden text-gray-900 font-bold shadow-xl hover:shadow-golden/50 transition-all hover:-translate-y-0.5"
-                onClick={() => window.open('https://academia.coinnecta.es/producto/suscripcion-mensual-academia/', '_blank')}
+                onClick={() => window.open('https://www.skool.com/coinnecta-8616', '_blank')}
               >
                 🤑 QUIERO GENERAR +$5K/MES
               </CTAButton>

--- a/src/components/landing/faq-section.tsx
+++ b/src/components/landing/faq-section.tsx
@@ -125,7 +125,7 @@ export function FAQSection() {
                   <CTAButton 
                     size="xl" 
                     className="w-full sm:w-auto"
-                    onClick={() => window.open('https://academia.coinnecta.es/producto/suscripcion-mensual-academia/', '_blank')}
+                    onClick={() => window.open('https://www.skool.com/coinnecta-8616', '_blank')}
                   >
                     🚀 Comenzar ahora
                   </CTAButton>

--- a/src/components/landing/hero-section.tsx
+++ b/src/components/landing/hero-section.tsx
@@ -143,7 +143,7 @@ export function HeroSection() {
               <CTAButton 
                 size="lg" 
                 className="w-full sm:w-auto hover:scale-105 transition-transform duration-300 shadow-lg shadow-golden/30 text-sm sm:text-base lg:text-base py-3 sm:py-4 px-6 sm:px-8 lg:px-8"
-                onClick={() => window.open('https://academia.coinnecta.es/producto/suscripcion-mensual-academia/', '_blank')}
+                onClick={() => window.open('https://www.skool.com/coinnecta-8616', '_blank')}
               >
                 🚀 COMENZAR AHORA
               </CTAButton>

--- a/src/components/landing/spots-card.tsx
+++ b/src/components/landing/spots-card.tsx
@@ -30,7 +30,7 @@ export default function SpotsCard({
   title = "50 plazas por mes",
   note = "No es una fórmula mágica. Es una estrategia real",
   ctaLabel = "Quiero Comenzar Ahora",
-  onCta = () => window.open('https://academia.coinnecta.es/producto/suscripcion-mensual-academia/', '_blank'),
+  onCta = () => window.open('https://www.skool.com/coinnecta-8616', '_blank'),
   className = "",
   includeTitle = "INCLUYE:",
   features = [
@@ -40,7 +40,7 @@ export default function SpotsCard({
     "Soporte personal",
     "Acceso inmediato",
   ],
-  price = 9.99,
+  price = 20,
   priceCurrency = "USD",
   priceBadge = "ÚNICO PAGO",
   includeNote = "Esto no es un gasto. Es la inversión más accesible que vas a hacer para cambiar tu situación financiera.",

--- a/src/components/landing/testimonials-section.tsx
+++ b/src/components/landing/testimonials-section.tsx
@@ -130,7 +130,7 @@ function VideoCarousel() {
           <CTAButton 
             size="xl" 
             className="w-full sm:w-auto bg-gradient-to-r from-golden to-amber-500 hover:from-amber-500 hover:to-golden text-gray-900 font-bold shadow-xl hover:shadow-2xl transition-all duration-300 hover:-translate-y-1 px-6 py-4 text-sm sm:text-base"
-            onClick={() => window.open('https://academia.coinnecta.es/producto/suscripcion-mensual-academia/', '_blank')}
+            onClick={() => window.open('https://www.skool.com/coinnecta-8616', '_blank')}
           >
            🚀 QUIERO COMENZAR AHORA
           </CTAButton>


### PR DESCRIPTION
## Summary
- update landing CTA buttons to open the new Skool checkout URL
- display the 20 USD offer price in the content banner and default spots card pricing

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68cd49175ea0832aa96b07901fbccadb